### PR TITLE
set limits on how far sound can be heard from looped sounds

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -314,6 +314,8 @@ public class Eln {
     public static boolean noSymbols = false;
     public static boolean noVoltageBackground = false;
 
+    public static double maxSoundDistance = 64;
+
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
 
@@ -464,6 +466,8 @@ public class Eln {
 
         Eln.noSymbols = config.get("general", "noSymbols", false).getBoolean();
         Eln.noVoltageBackground = config.get("general", "noVoltageBackground", false).getBoolean();
+
+        Eln.maxSoundDistance = config.get("debug", "maxSoundDistance", 64.0).getDouble();
 
         config.save();
 

--- a/src/main/java/mods/eln/sound/LoopedSoundManager.kt
+++ b/src/main/java/mods/eln/sound/LoopedSoundManager.kt
@@ -1,5 +1,6 @@
 package mods.eln.sound
 
+import mods.eln.Eln
 import net.minecraft.client.Minecraft
 
 class LoopedSoundManager(val updateInterval: Float = 0.5f) {
@@ -19,15 +20,26 @@ class LoopedSoundManager(val updateInterval: Float = 0.5f) {
         if (remaining <= 0) {
             val soundHandler = Minecraft.getMinecraft().soundHandler
             loops.forEach {
-                if (it.volume > 0 && it.pitch > 0 && !soundHandler.isSoundPlaying(it)) {
+                val x = it.coord.x
+                val y = it.coord.y
+                val z = it.coord.z
+                val player = Minecraft.getMinecraft().thePlayer
+                val distance = player.getDistance(x.toDouble(), y.toDouble(), z.toDouble())
+                if (it.volume > 0 && it.pitch > 0 && !soundHandler.isSoundPlaying(it) && distance < Eln.maxSoundDistance) {
                     try {
                         soundHandler.playSound(it)
                     } catch (e: IllegalArgumentException) {
                         System.out.println(e)
                     }
                 }
+                if (distance >= Eln.maxSoundDistance || it.volume == 0f || it.pitch == 0f) {
+                    try{
+                        soundHandler.stopSound(it)
+                    } catch (e: Exception) {
+                        System.out.println(e)
+                    }
+                }
             }
-
             remaining = updateInterval
         }
     }


### PR DESCRIPTION
Attempting to fix the sound bug by restricting how far away sounds can be heard.

The root of the problem is that we need <20 sound sources, but I can't see a clear way to limit that. Instead, I went with the route of limiting how far away things can be heard.

I created a new configuration value in Eln.cfg under `debug`: `D: maxSoundDistance = 64`

Reducing the value to around `5` appears to reduce the chances of >20 sound sources to be active to about none. Sparse equipment can be around `16` blocks apart, and the default is `64` blocks away from the player. I don't think sounds go that far even...