### PR TITLE
Make turrets ignore previous invulnerability timer

### DIFF
--- a/src/main/java/mods/eln/transparentnode/turret/TurretSlowProcess.java
+++ b/src/main/java/mods/eln/transparentnode/turret/TurretSlowProcess.java
@@ -319,7 +319,10 @@ public class TurretSlowProcess extends StateMachine {
 
         @Override
         public void enter() {
-            if (target != null) target.attackEntityFrom(new DamageSource("Unknown"), 5);
+            if (target != null) {
+                target.hurtResistantTime = 0;
+                target.attackEntityFrom(new DamageSource("Unknown"), 5);
+            }
             element.shoot();
             element.play(new SoundCommand("eln:LaserGun"));
         }


### PR DESCRIPTION
Really quick fix, and _really_ deadly for high-power turrets that refire quickly.