### PR TITLE
Making mining pipes and alloy dust a bit less grindy

### DIFF
--- a/src/main/java/mods/eln/Eln.java
+++ b/src/main/java/mods/eln/Eln.java
@@ -6808,7 +6808,7 @@ public class Eln {
     }
 
     private void recipeDust() {
-        addShapelessRecipe(findItemStack("Alloy Dust", 2),
+        addShapelessRecipe(findItemStack("Alloy Dust", 6),
             "dustIron",
             "dustCoal",
             dictTungstenDust,
@@ -6972,7 +6972,7 @@ public class Eln {
     }
 
     private void recipeMiningPipe() {
-        addRecipe(findItemStack("Mining Pipe", 4),
+        addRecipe(findItemStack("Mining Pipe", 12),
             "A",
             "A",
             'A', "ingotAlloy");


### PR DESCRIPTION
I know that this is a controversial issue, so I was hoping that we could have a sane conversation about adjusting the cost of tungsten related products.

These changes are to the alloy recipe and the mining pipe recipe, which are both poorly balanced. I have 3x'd the output of both of them.

I 3x'd the alloy dust output, since you are putting in 6 dust, and theoretically you are mixing the dust, you should get 6 out. It just makes sense unless you're dumping more than half the dust on the ground. This has far-reaching results, including making 200v more achievable, which should be the logical next step (rather than many/most players directly jumping to 800v or 3.2kV, which doesn't make as much sense).

I 3x'd the mining pipe because it was a bit excessive to have to create 64 pipes  (which required at least a stack of alloy ingots, which was over 2 stacks of tungsten dust, so over a stack of tungsten ore was required which is ridiculous for something that seems almost as rare as diamonds). Now, in order to get 64 mining pipe (enough to reach the bottom of the world at sea level, reasonable), you only need about 24 alloy ingots, which is much more reasonable.