### PR TITLE
Add High-Grade Kerosene as a fluid fuel

### DIFF
--- a/src/main/java/mods/eln/fluid/FuelRegistry.kt
+++ b/src/main/java/mods/eln/fluid/FuelRegistry.kt
@@ -29,6 +29,7 @@ object FuelRegistry {
         "bioethanol" to 17826480.0, // Forestry
         "gasoline" to 25820000.0, // PneumaticCraft, density = 0.755 kg/L, heat value = 34,2 MJ/l
         "kerosene" to 34800000.0, // PneumaticCraft, heat value = 34,8 MJ/l
+        "highgradekerosene" to 39200000.0, // Silfryi's ContentTweaker scripts, Refined Form of Kerosene, heat value = 39,2 MJ/l
         "lpg" to 24840000.0, // PneumaticCraft, density = 0.54 kg/l, heat value = 46 MJ/kg
         "fuelgc" to 31570000.0, // GalactiCraft, see "fuel"
         "lightoil" to 35358000.0    // Magneticraft, density = 0.83 kg/l, heating value = 42.6 MJ/kg


### PR DESCRIPTION
Higher energy density than kerosene, closer to the max of kerosene-type fuels.
<https://www.engineeringtoolbox.com/fuels-densities-specific-volumes-d_166.html> Highest density from here (840 kg/m^3)
<https://neutrium.net/properties/specific-energy-and-energy-density-of-fuels/> then the 46,2 MJ/kg from here
Gets 38,808 MJ/L
Now, as this is more refined than traditional kerosene, I put it got put at 39,2 because of lower sulfur content reducing polymerization. You can revert to 38,808 if you want, it's slightly closer. 

Addition is 99% for my modpack, because I know of no mod that adds it.

<https://polymerdatabase.com/polymer%20chemistry/Vulcanization.html> There's a couple places that mention sulfur extremely helping polymerization. Here's one.