### PR TITLE
Fixed HubRender

### DIFF
--- a/src/main/java/mods/eln/sixnode/hub/HubRender.java
+++ b/src/main/java/mods/eln/sixnode/hub/HubRender.java
@@ -46,10 +46,10 @@ public class HubRender extends SixNodeElementRender {
                 ItemStack cableStack = Utils.unserialiseItemStack(stream);
                 if (cableStack != null) {
                     ElectricalCableDescriptor desc = (ElectricalCableDescriptor) ElectricalCableDescriptor.getDescriptor(cableStack, ElectricalCableDescriptor.class);
-                    if (desc == null)
-                        cableRender[idx] = null;
-                    else
+                    if(desc != null) {
                         cableRender[idx] = desc.render;
+                        continue;
+                    }
                 }
                 cableRender[idx] = null;
             }


### PR DESCRIPTION
Should normally fix the HubRender, so that the cables are visible again in the game.