### PR TITLE
Publish all elements after network rebuild

### DIFF
--- a/src/main/java/mods/eln/mechanical/ShaftNetwork.kt
+++ b/src/main/java/mods/eln/mechanical/ShaftNetwork.kt
@@ -257,9 +257,17 @@ open class ShaftNetwork() : INBTTReady {
             // Utils.println("SN.rN new shaft, unseen.size = " + unseen.size)
             // We ran out of network. Any elements remaining in unseen should thus form a new network.
             shaft.updateCache()
+            shaft.elements.forEach { it.needPublish() }
             shaft = ShaftNetwork()
             shaft.rads = curRads
         }
+
+        // Before we exit, make sure the last shaft constructed has its cache rebuilt.
+        shaft.updateCache()
+        shaft.elements.forEach { it.needPublish() }
+
+        // At this point, it's likely that `this` is no longer referenced by
+        // any object and will be dropped on return.
 
         // Utils.println("SN.rN ----- FINISH -----")
     }


### PR DESCRIPTION
After some mutual review, it looks like this closes #158 , since the "corruption" in question is merely some client desynchronization.

Untested, but ready for review (I anticipate the change is trivial enough).