### PR TITLE
Tutorial sign is now multilanguage

### DIFF
--- a/src/main/java/mods/eln/misc/Utils.kt
+++ b/src/main/java/mods/eln/misc/Utils.kt
@@ -15,9 +15,9 @@ import org.lwjgl.opengl.GL11
 import net.minecraft.world.World
 import cpw.mods.fml.common.FMLCommonHandler
 import cpw.mods.fml.relauncher.Side
+import jdk.nashorn.internal.runtime.Debug
 import net.minecraftforge.common.DimensionManager
 import net.minecraft.entity.item.EntityItem
-import java.io.IOException
 import net.minecraft.tileentity.TileEntity
 import net.minecraft.client.Minecraft
 import net.minecraft.world.EnumSkyBlock
@@ -43,16 +43,12 @@ import net.minecraft.util.ChatComponentText
 import net.minecraft.world.IBlockAccess
 import kotlin.jvm.JvmOverloads
 import net.minecraft.item.crafting.FurnaceRecipes
-import java.io.FileInputStream
 import mods.eln.misc.Obj3D.Obj3DPart
 import net.minecraft.block.Block
 import net.minecraft.entity.Entity
 import net.minecraft.item.Item
 import net.minecraft.world.chunk.Chunk
-import java.io.ByteArrayOutputStream
-import java.io.DataInputStream
-import java.io.DataOutputStream
-import java.io.File
+import java.io.*
 import java.lang.ClassNotFoundException
 import java.lang.Exception
 import java.lang.IllegalArgumentException
@@ -1213,6 +1209,11 @@ object Utils {
         fis.read(data)
         fis.close()
         return String(data, Charset.defaultCharset())
+    }
+
+    @JvmStatic
+    fun mapFileExists(path: String): Boolean {
+        return getMapFile(path).exists();
     }
 
     @JvmStatic

--- a/src/main/java/mods/eln/misc/Utils.kt
+++ b/src/main/java/mods/eln/misc/Utils.kt
@@ -15,7 +15,6 @@ import org.lwjgl.opengl.GL11
 import net.minecraft.world.World
 import cpw.mods.fml.common.FMLCommonHandler
 import cpw.mods.fml.relauncher.Side
-import jdk.nashorn.internal.runtime.Debug
 import net.minecraftforge.common.DimensionManager
 import net.minecraft.entity.item.EntityItem
 import net.minecraft.tileentity.TileEntity
@@ -48,7 +47,12 @@ import net.minecraft.block.Block
 import net.minecraft.entity.Entity
 import net.minecraft.item.Item
 import net.minecraft.world.chunk.Chunk
-import java.io.*
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+import java.io.FileInputStream
+import java.io.File
 import java.lang.ClassNotFoundException
 import java.lang.Exception
 import java.lang.IllegalArgumentException

--- a/src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignElement.java
+++ b/src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignElement.java
@@ -12,12 +12,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import scala.Console;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 
+import static mods.eln.i18n.I18N.getCurrentLanguage;
 import static mods.eln.i18n.I18N.tr;
 
 public class TutorialSignElement extends SixNodeElement {
@@ -35,8 +37,7 @@ public class TutorialSignElement extends SixNodeElement {
     public static String getText(String balise) {
         if (baliseMap == null) {
             baliseMap = new HashMap<String, String>();
-
-		/*
+            /*
 			try {
 				File fXmlFile = Utils.getMapFile("EA/tutorialSign.xml");
 				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
@@ -53,49 +54,52 @@ public class TutorialSignElement extends SixNodeElement {
 				int i = 0;
 			} catch (Exception e) {
 			}
-*/
+            */
             //optional, but recommended
             //read this - http://stackoverflow.com/questions/13786607/normalization-in-dom-parsing-with-java-how-does-it-work
             //doc.getDocumentElement().normalize();
-
-            try {
-                String file = Utils.readMapFile("EA/tutorialSign.txt");
-                String ret;
-                if (file.contains("\r\n"))
-                    ret = "\r\n";
-                else
-                    ret = "\n";
-
-                file = file.replaceAll("#" + ret, "#");
-                file = file.replaceAll(ret + "#", "#");
-
-                String[] split = file.split("#");
-
-                boolean first = true;
-                int counter = 0;
-                String baliseTag = "";
-
-                for (String str : split) {
-                    if (first) {
-                        first = false;
-                        continue;
-                    }
-                    if (counter == 0) {
-                        baliseTag = str;
-                    }
-                    if (counter == 1) {
-                        baliseMap.put(baliseTag, str);
-                    }
-
-                    counter = (counter + 1) & 1;
-                }
-            } catch (IOException e) {
-                //	e.printStackTrace();
-            }
+            String localizedPath = "EA/tutorialSign/" + getCurrentLanguage() + ".txt"; //localized file path
+            String defaultPath = "EA/tutorialSign/en_US.txt"; //if the localized file is not found, then load the default file (en_US)
+            String oldPath = "EA/tutorialSign.txt"; //for compatibility
+            if(Utils.mapFileExists(localizedPath))
+                loadMapFromPath(localizedPath);
+            else if(Utils.mapFileExists(defaultPath))
+                loadMapFromPath(defaultPath);
+            else
+                loadMapFromPath(oldPath);
         }
         String text = baliseMap.get(balise);
         if (text == null) return tr("No text associated to this beacon");
         return text;
+    }
+
+    private static void loadMapFromPath(String path) {
+        try {
+            String file = Utils.readMapFile(path);
+            String ret;
+            if (file.contains("\r\n"))
+                ret = "\r\n";
+            else
+                ret = "\n";
+
+            file = file.replaceAll("#" + ret, "#");
+            file = file.replaceAll(ret + "#", "#");
+
+            String[] split = file.split("#");
+
+            boolean add = false;
+            String baliseTag = "";
+
+            for (String str : split) {
+                if (add)
+                    baliseMap.put(baliseTag, str);
+                else
+                    baliseTag = str;
+                add = !add;
+            }
+        } catch (IOException e) {
+            //	e.printStackTrace();
+        }
     }
 
     public TutorialSignElement(SixNode sixNode, Direction side, SixNodeDescriptor descriptor) {

--- a/src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignElement.java
+++ b/src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignElement.java
@@ -83,8 +83,12 @@ public class TutorialSignElement extends SixNodeElement {
             else
                 ret = "\n";
 
+            file = file.trim();
             file = file.replaceAll("#" + ret, "#");
             file = file.replaceAll(ret + "#", "#");
+
+            if(file.charAt(0) == '#')
+                file = file.substring(1);
 
             String[] split = file.split("#");
 

--- a/src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignElement.java
+++ b/src/main/java/mods/eln/sixnode/tutorialsign/TutorialSignElement.java
@@ -12,8 +12,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import scala.Console;
-
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -58,15 +56,18 @@ public class TutorialSignElement extends SixNodeElement {
             //optional, but recommended
             //read this - http://stackoverflow.com/questions/13786607/normalization-in-dom-parsing-with-java-how-does-it-work
             //doc.getDocumentElement().normalize();
-            String localizedPath = "EA/tutorialSign/" + getCurrentLanguage() + ".txt"; //localized file path
-            String defaultPath = "EA/tutorialSign/en_US.txt"; //if the localized file is not found, then load the default file (en_US)
+            String localizedPath = "EA/tutorialSign/" + getCurrentLanguage() + ".lang"; //localized file path
+            String defaultPath = "EA/tutorialSign/en_US.lang"; //if the localized file is not found, then load the default file (en_US)
             String oldPath = "EA/tutorialSign.txt"; //for compatibility
             if(Utils.mapFileExists(localizedPath))
                 loadMapFromPath(localizedPath);
-            else if(Utils.mapFileExists(defaultPath))
+            else if(Utils.mapFileExists(defaultPath)) {
+                Utils.println(getCurrentLanguage() + " translation is missing. The default en_US translation will be used.");
                 loadMapFromPath(defaultPath);
-            else
+            } else {
+                Utils.println("Default en_US translation is missing. Old .txt translation will be used.");
                 loadMapFromPath(oldPath);
+            }
         }
         String text = baliseMap.get(balise);
         if (text == null) return tr("No text associated to this beacon");
@@ -98,7 +99,7 @@ public class TutorialSignElement extends SixNodeElement {
                 add = !add;
             }
         } catch (IOException e) {
-            //	e.printStackTrace();
+            Utils.println(e);
         }
     }
 


### PR DESCRIPTION
The training sign now supports multilingualism.
The new file structure should look like this:

```
.\EA\
.\EA\tutorialSign\
.\EA\tutorialSign\en_US.lang
.\EA\tutorialSign\<language_code>.lang
.\EA\tutorialSign\...
.\EA\tutorialSign\tutorialSign.txt
```
Where `<language_code>` is "en_US", "ru_RU", "en_UK" etc.

1. If the file `.\EA\tutorialSign\<current_language_code>.lang` exists, it is loaded.
2. Otherwise, if the file `.\EA\tutorialSign\en_US.lang` exists, it is loaded.
3. Otherwise, the file `.\EA\tutorialSign.txt` is loaded.

Support for the  `tutorialSign.txt` file is left for compatibility.